### PR TITLE
Pypardiso v0.3.2

### DIFF
--- a/recipes/pypardiso/meta.yaml
+++ b/recipes/pypardiso/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pypardiso" %}
-{% set version = "0.3.1" %}
+{% set version = "0.3.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,8 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: c3846870dc2590250980d98568e9dfc99b0271e9e5a9c8714a85cc373e839788
-
+  sha256: 1116ffeedf49bb31fdeea2d45076ddf540955c4df272fc4c8bc6b17c4f9d267e
 build:
   number: 0
   script: "{{ PYTHON }} -m pip install . -vv"

--- a/recipes/pypardiso/meta.yaml
+++ b/recipes/pypardiso/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = "pypardiso" %}
-{% set version = "0.3" %}
+{% set version = "0.3.1" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://github.com/haasad/PyPardisoProject/archive/refs/tags/v0.3.0.tar.gz
-  sha256: b054262e1e58cd57660d6ebbfcac2a45ee01891dbe74bd31fcb5e69e3c07de19
+  url: https://github.com/haasad/PyPardisoProject/archive/refs/tags/v0.3.1.tar.gz
+  sha256: 41cb729c1fa9e69393d2f1d73f8758282f34a553ef333ad165f3fd41447518db
 
 build:
   number: 0


### PR DESCRIPTION
Bump to v0.3.2 to fix failing `pip check` issue that's stopping https://github.com/conda-forge/staged-recipes/pull/15106 from being merged.